### PR TITLE
Fix GeneratedLexer build on macOS

### DIFF
--- a/Module3/GeneratedLexer.csproj
+++ b/Module3/GeneratedLexer.csproj
@@ -98,7 +98,4 @@
   <ProjectExtensions>
     <VisualStudio AllowExistingFolder="true" />
   </ProjectExtensions>
-  <PropertyGroup>
-    <PreBuildEvent>dir</PreBuildEvent>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Looks like there was useless, but seemed harmless call 'dir', somehow invisible for MSVS, which stopped proj from building on macOS, removed it.
This change doesn't affect build on Windows and shouldn't affect Linux.